### PR TITLE
return true so no error is returned to the client

### DIFF
--- a/mod_eventlog.lua
+++ b/mod_eventlog.lua
@@ -38,6 +38,7 @@ module:hook("message/host", function (event)
                 value = value
             });
         end
+        return true;
     elseif logType == "log" then
         local level = log_levels[log.attr.type] or "info";
         local message = log:get_child_text("message", xmlns_log);
@@ -46,6 +47,7 @@ module:hook("message/host", function (event)
         end
 
         module:log(level, "CLIENTLOG: %s", message);
+        return true;
     end
 end);
 


### PR DESCRIPTION
trying to reland... those messages should be handled by something, otherwise an error is returned to the client
